### PR TITLE
Fix 129039 test for ggencoder 1.0.10 AIS Class B encoding

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "license": "ISC",
   "dependencies": {
     "@canboat/ts-pgns": "^1.10.2",
-    "ggencoder": "^1.0.0"
+    "ggencoder": "^1.0.10"
   },
   "repository": {
     "type": "git",

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -153,8 +153,8 @@ versions.forEach((version) => {
         lat: 39.070026666666664,
         sog: 4.7,
         cog: 122,
-        hdg: 122,
-        utc: 56
+        hdg: 511,
+        utc: 60
       }
 
       try {


### PR DESCRIPTION
The `129039 works` test (all 4 server-version variants) fails against the current **ggencoder 1.0.10**.

**Root cause:** ggencoder 1.0.10 corrected AIS Class B (type 18) encoding. For the test's input — a 129039 with **no true heading** and an unset AIS time stamp — the decoded message is now:
- `hdg: 511` ("not available") — previously 1.0.9 fell back to COG (122)
- `utc: 60` ("not available") — previously 1.0.9 produced 56

The fixtures were pinned to the old ggencoder 1.0.9 output (`hdg: 122`, `utc: 56`). This isn't a canboat/ts-pgns change — I verified by holding ts-pgns constant and only bumping ggencoder 1.0.9 → 1.0.10, which flips the values exactly.

**This change:** update the 129039 expected `hdg`/`utc` to `511`/`60` and require `ggencoder ^1.0.10`. All 24 tests pass.

Possible follow-up (out of scope here): the `convert` path for 129039 doesn't propagate the source PGN's `Time Stamp` into the AIS second, so it always reports "not available" — could be wired through if desired.

This also unblocks canboat's downstream integration job ("Test canboatjs, ts-pgns and related Signal K projects"), which fresh-installs the latest ggencoder and currently fails on every PR because of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)