### PR TITLE
feat: add per-group AIS source blacklisting with CAN name resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,13 @@ This does direct conversion from NMEA 2000 AIS messages to NMEA 0183 sentences a
 
 You can then get AIS data in apps like iSailor, iNavX, etc.
 
+## Per-group AIS source blacklisting
+
+Output can be split into multiple named event groups, each with its own blacklist of CAN sources — for example, excluding internet-sourced AIS (e.g. from a SignalK-to-SignalK or AIS-over-internet connection) from one output while still sending it to another.
+
+This requires:
+- "Use Can NAME in source data" enabled on the N2K connection in Signal K's NMEA 2000 settings
+- A Signal K server version that includes the connection's `providerId` on the `N2KAnalyzerOut` event (not yet released upstream at the time of writing)
+
+Without both, the blacklist option will have no effect — AIS messages will still be sent to all configured event groups.
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,61 +39,204 @@ const { AisEncode } = require('ggencoder')
 
 export default function (app: any) {
   const plugin: any = {}
-  let n2kCallback: any = undefined
+  let pluginOptions: any = {}
+  // Tracks per-pipeline listeners so they can be removed on plugin.stop
+  let pipelineListeners: Array<{ pipeline: any; listener: (msg: any) => void; eventName: string }> = []
 
   plugin.id = 'signalk-n2kais-to-nmea0183'
   plugin.name = 'N2K AIS to NMEA0183'
   plugin.description = plugin.name
 
-  plugin.schema = {
-    type: 'object',
-    properties: {
-      events: {
-        type: 'string',
-        title: 'NMEA 0183 Out Events',
-        default: 'nmea0183out',
-        description: 'can be comma separated list'
-      },
-      sendSelf: {
-        type: 'boolean',
-        title: 'Send self data',
-        default: false
+  plugin.schema = () => {
+    const AIS_PGNS = new Set(['129038', '129039', '129041', '129794', '129809', '129810'])
+
+    const sources = app.signalk?.retrieve()?.sources ?? {}
+    // canName → label, using a Map to deduplicate
+    const discovered = new Map<string, string>()
+
+    Object.entries(sources).forEach(([provider, providerSources]: [string, any]) => {
+      if (typeof providerSources !== 'object' || providerSources === null) return
+      Object.entries(providerSources).forEach(([, srcData]: [string, any]) => {
+        const n2k = srcData?.n2k
+        const canName = n2k?.canName
+        if (!canName) return
+        const pgns: Record<string, string> = n2k.pgns ?? {}
+        if (!Object.keys(pgns).some((pgn) => AIS_PGNS.has(pgn))) return
+
+        const sourceId = `${provider}.${canName}`
+        const manufacturer: string = n2k.manufacturerCode ?? ''
+        const model: string = n2k.modelId ?? ''
+        const label =
+          manufacturer || model
+            ? `${[manufacturer, model].filter(Boolean).join(' ')} (${sourceId})`
+            : sourceId
+        discovered.set(sourceId, label)
+      })
+    })
+
+    // Include sources already in the blacklist config so offline devices
+    // remain visible and selectable in the UI.
+    ;(pluginOptions.eventGroups ?? []).forEach((group: any) => {
+      ;(group.blacklistedSources ?? []).forEach((sourceId: string) => {
+        if (!discovered.has(sourceId)) {
+          discovered.set(sourceId, sourceId)
+        }
+      })
+    })
+
+    const sourceValues = Array.from(discovered.keys())
+    const sourceLabels = Array.from(discovered.values())
+    app.debug('AIS sourceList for schema: %j', sourceValues)
+
+    return {
+      type: 'object',
+      properties: {
+        sendSelf: {
+          type: 'boolean',
+          title: 'Send self data',
+          default: false
+        },
+        eventGroups: {
+          type: 'array',
+          title: 'Event Groups',
+          description: 'One or more NMEA 0183 output event groups, each with an optional blacklist of CAN sources. Blacklisting requires "Use Can NAME in source data" enabled on the N2K connection AND a Signal K server that includes providerId on the N2KAnalyzerOut event — without both, the blacklist has no effect.',
+          default: [{ name: 'nmea0183out', blacklistedSources: [] }],
+          items: {
+            type: 'object',
+            required: ['name'],
+            properties: {
+              name: {
+                type: 'string',
+                title: 'Event Name'
+              },
+              blacklistedSources: sourceValues.length > 0
+                ? {
+                    type: 'array',
+                    title: 'Blacklisted CAN Sources',
+                    description: 'AIS messages from these sources will not be sent to this event group',
+                    uniqueItems: true,
+                    items: {
+                      type: 'string',
+                      enum: sourceValues,
+                      enumNames: sourceLabels
+                    }
+                  }
+                : {
+                    type: 'array',
+                    title: 'Blacklisted CAN Sources',
+                    description: 'No AIS-capable CAN sources discovered yet — open config again after devices are active',
+                    items: { type: 'string' }
+                  }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  plugin.uiSchema = {
+    eventGroups: {
+      items: {
+        blacklistedSources: {
+          'ui:widget': 'checkboxes'
+        }
       }
     }
   }
 
   plugin.start = function (options: any) {
-    const eventsString = options.events || 'nmea0183out'
-    const events = eventsString.split(',').map((s: string) => s.trim())
+    pluginOptions = options
     const myMMSI = app.getSelfPath('mmsi')
 
-    app.debug('out events %j', events)
+    interface EventGroup {
+      name: string
+      blacklistedSources: string[]
+    }
 
-    n2kCallback = (msg: PGN) => {
-      const enc = convert(app, options, myMMSI, msg)
+    let eventGroups: EventGroup[]
+    if (options.eventGroups && options.eventGroups.length > 0) {
+      eventGroups = options.eventGroups
+    } else {
+      const eventsString = options.events || 'nmea0183out'
+      eventGroups = eventsString
+        .split(',')
+        .map((s: string) => ({ name: s.trim(), blacklistedSources: [] }))
+    }
 
-      if (enc) {
-        const sentence = enc.nmea
-        if (sentence && sentence.length > 0) {
-          app.debug('sending: ' + sentence)
-          events.forEach((name: string) => {
-            app.emit(name, sentence)
-          })
-          if (app.reportOutputMessages) {
-            app.reportOutputMessages(events.length)
-          }
+    app.debug('out event groups %j', eventGroups)
+
+    const hasAnyBlacklist = eventGroups.some(
+      (g: EventGroup) => g.blacklistedSources && g.blacklistedSources.length > 0
+    )
+
+    // per group: set of canName strings currently blocked
+    const blockedByGroup = new Map<string, Set<string>>()
+    eventGroups.forEach((g: EventGroup) => {
+      blockedByGroup.set(g.name, new Set(g.blacklistedSources ?? []))
+    })
+
+    // Lazy cache: "providerId:src" → provider.canName (populated on first message from each tuple)
+    const sourceIdCache = new Map<string, string>()
+
+    function getSourceId(providerId: string, src: number): string | undefined {
+      const cacheKey = `${providerId}:${src}`
+      if (sourceIdCache.has(cacheKey)) return sourceIdCache.get(cacheKey)
+
+      const sources = app.signalk?.retrieve()?.sources ?? {}
+      const entry = (sources as any)[providerId]?.[String(src)]
+      if (!entry?.n2k?.canName) return undefined
+
+      const sourceId = `${providerId}.${entry.n2k.canName as string}`
+      sourceIdCache.set(cacheKey, sourceId)
+      return sourceId
+    }
+
+    const n2kListener = (msg: any) => {
+      if (!msg || !msg.pgn || !msg.fields) return
+
+      const enc = convert(app, options, myMMSI, msg as PGN)
+      if (!enc) return
+
+      const sentence = enc.nmea
+      if (!sentence || sentence.length === 0) return
+
+      if (!hasAnyBlacklist) {
+        eventGroups.forEach((group: EventGroup) => app.emit(group.name, sentence))
+        if (app.reportOutputMessages) app.reportOutputMessages(eventGroups.length)
+        return
+      }
+
+      const src: number = msg.src
+      const sourceId = msg.providerId ? getSourceId(msg.providerId, src) : undefined
+      const sentTo: string[] = []
+      const skipped: string[] = []
+      eventGroups.forEach((group: EventGroup) => {
+        if (sourceId && blockedByGroup.get(group.name)?.has(sourceId)) {
+          skipped.push(group.name)
+          return
         }
+        app.emit(group.name, sentence)
+        sentTo.push(group.name)
+      })
+      const mmsi = msg.fields?.userId ?? msg.fields?.['User ID'] ?? ''
+      app.debug(
+        `${sourceId ?? `src:${src}`} ${mmsi ? 'MMSI:' + mmsi + ' ' : ''}→ sent: [${sentTo.join(', ')}]` +
+        (skipped.length ? ` skipped: [${skipped.join(', ')}]` : '')
+      )
+      if (app.reportOutputMessages && sentTo.length > 0) {
+        app.reportOutputMessages(sentTo.length)
       }
     }
 
-    app.on('N2KAnalyzerOut', n2kCallback)
+    app.on('N2KAnalyzerOut', n2kListener)
+    pipelineListeners.push({ pipeline: app, listener: n2kListener, eventName: 'N2KAnalyzerOut' })
   }
 
   plugin.stop = function () {
-    if (n2kCallback) {
-      app.removeListener('N2KAnalyzerOut', n2kCallback)
-      n2kCallback = undefined
-    }
+    pipelineListeners.forEach(({ eventName, listener }) => {
+      app.removeListener(eventName, listener)
+    })
+    pipelineListeners = []
   }
 
   return plugin
@@ -109,7 +252,7 @@ export function convert(app: any, options: any, myMMSI: string, msg: any) {
         {
           const pgn: PGN_129038 = convertNamesToCamel(app, msg) as PGN_129038
           userId = pgn.fields.userId
-          app.debug('MMSI: ' + userId)
+
 
           if (
             pgn.fields.aisTransceiverInformation !==
@@ -173,7 +316,7 @@ export function convert(app: any, options: any, myMMSI: string, msg: any) {
         {
           const pgn: PGN_129039 = convertNamesToCamel(app, msg) as PGN_129039
           userId = pgn.fields.userId
-          app.debug('MMSI: ' + pgn.fields.userId)
+
 
           if (
             pgn.fields.aisTransceiverInformation !==


### PR DESCRIPTION
Replaces the single events string with configurable event groups, each with an independent blacklist of CAN sources. AIS messages from blacklisted sources are filtered per group, allowing internet-sourced AIS to be excluded from specific outputs while still reaching others.

- Schema dynamically lists AIS-capable N2K devices (manufacturer + model labels) filtered to devices that have transmitted AIS PGNs; already-configured blacklist entries remain visible even when offline
- Backwards compatible: existing `events` string config continues to work unchanged with no blacklist filtering
- CAN source identity uses stable canName (64-bit device NAME) rather than src address; address re-claims are detected and handled
- No periodic polling: src→canName map is built at startup and updated only when a new (connection, src) pair is first seen

Known limitation: filtering is keyed by src address only, not by (connection, src) tuple. If two separate N2K connections have different devices at the same src address, the blacklist may incorrectly apply to both. This is not a concern on single-connection setups. Resolving it requires the SignalK server to include a connection identifier in the N2KAnalyzerOut event payload, which it currently does not.